### PR TITLE
ANDROID: sdcardfs: d_splice_alias can return error values

### DIFF
--- a/fs/sdcardfs/lookup.c
+++ b/fs/sdcardfs/lookup.c
@@ -199,7 +199,8 @@ static struct dentry *__sdcardfs_interpose(struct dentry *dentry,
 
 	ret_dentry = d_splice_alias(inode, dentry);
 	dentry = ret_dentry ?: dentry;
-	update_derived_permission_lock(dentry);
+	if (!IS_ERR(dentry))
+		update_derived_permission_lock(dentry);
 out:
 	return ret_dentry;
 }


### PR DESCRIPTION
We must check that d_splice_alias was successful before using its
output.

Signed-off-by: Daniel Rosenberg <drosen@google.com>
Bug: 62390017
Change-Id: Ifda0a052fb3f67e35c635a4e5e907876c5400978